### PR TITLE
DATAMONGO-919 - Upgrade aspectj to 1.8

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -104,7 +104,7 @@
 		<!-- dist.secretKey -->
 
 		<apt>1.1.1</apt>
-		<aspectj>1.7.4</aspectj>
+		<aspectj>1.8.0</aspectj>
 		<cdi>1.0</cdi>
 		<hamcrest>1.3</hamcrest>
 		<jackson>2.3.2</jackson>


### PR DESCRIPTION
The upgrade to `aspectj 1.8` will allow us, in combination with an upgrade of `aspectj-maven-plugin` to `1.6`, to build spring-data-mongodb Cross-Store Support with java 8.
