### PR TITLE
Change Spring framework to 5.0.2.BUILD-SNAPSHOT

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -107,7 +107,7 @@
 		<rxjava-reactive-streams>1.2.1</rxjava-reactive-streams>
 		<rxjava2>2.1.6</rxjava2>
 		<slf4j>1.7.25</slf4j>
-		<spring>5.0.2.RELEASE</spring>
+		<spring>5.0.2.BUILD-SNAPSHOT</spring>
 		<spring-hateoas>0.23.0.RELEASE</spring-hateoas>
 		<threetenbp>1.3.6</threetenbp>
 		<validation>1.1.0.Final</validation>


### PR DESCRIPTION
Spring framework 5.0.2.RELEASE is not available in Maven Central yet: https://mvnrepository.com/artifact/org.springframework/spring-framework-bom