### PR TITLE
Doc output

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -341,12 +341,6 @@
 								<phase>generate-resources</phase>
 								<configuration>
 									<target>
-<!--										<copy todir="${project.root}/target/site/reference/html">
-											<fileset dir="${shared.resources}/asciidoc" erroronmissingdir="false">
-												<include name="**/*.css"/>
-											</fileset>
-											<flattenmapper/>
-										</copy> -->
 										<copy todir="${project.root}/target/site/reference/html/images">
 											<fileset dir="${basedir}/src/main/asciidoc" erroronmissingdir="false">
 												<include name="**/*.png"/>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -244,11 +244,19 @@
 
 			<properties>
 				<shared.resources>${project.build.directory}/shared-resources</shared.resources>
+				<doc.resources>${project.build.directory}/doc-resources</doc.resources>
 				<maven.install.skip>true</maven.install.skip>
 				<skipTests>true</skipTests>
 			</properties>
 
 			<dependencies>
+				<dependency>
+					<groupId>org.springframework.doc-resources</groupId>
+					<artifactId>spring-doc-resources</artifactId>
+					<version>0.1.1-SNAPSHOT</version>
+					<scope>provided</scope>
+					<type>zip</type>
+				</dependency>
 				<dependency>
 					<groupId>org.springframework.data.build</groupId>
 					<artifactId>spring-data-build-resources</artifactId>
@@ -284,6 +292,31 @@
 							<includeTypes>zip</includeTypes>
 							<excludeTransitive>true</excludeTransitive>
 							<outputDirectory>${shared.resources}</outputDirectory>
+						</configuration>
+					</plugin>
+
+					<!--
+						Unpacks the content of spring-doc-resources into the doc resources folder.
+					-->
+
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-dependency-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>unpack-shared-resources</id>
+								<goals>
+									<goal>unpack-dependencies</goal>
+								</goals>
+								<phase>initialize</phase>
+							</execution>
+						</executions>
+						<configuration>
+							<includeGroupIds>org.springframework.doc-resources</includeGroupIds>
+							<includeArtifactIds>spring-doc-resources</includeArtifactIds>
+							<includeTypes>zip</includeTypes>
+							<excludeTransitive>true</excludeTransitive>
+							<outputDirectory>${doc.resources}</outputDirectory>
 						</configuration>
 					</plugin>
 
@@ -375,6 +408,36 @@
 							</execution>
 
 							<execution>
+								<id>create-docs-working-directory</id>
+								<phase>initialize</phase>
+								<configuration>
+									<target>
+										<copy failonerror="false" file="${project.build.directory}/doc-resources/stylesheets/spring.css" tofile="${project.build.directory}/working/stylesheets/spring.css"/>
+										<copy failonerror="false" file="${project.build.directory}/doc-resources/html/docinfo.html" tofile="${project.build.directory}/working/docinfo.html"/>
+										<copy failonerror="false" file="${project.build.directory}/doc-resources/html/docinfo-footer.html" tofile="${project.build.directory}/working/docinfo-footer.html"/>
+										<copy failonerror="false" todir="${project.build.directory}/working/tocbot-3.0.2">
+											<fileset dir="${project.build.directory}/doc-resources/javascript/tocbot-3.0.2">
+												<include name="*.*"/>
+											</fileset>
+										</copy>
+										<copy failonerror="false" todir="${project.build.directory}/working">
+											<fileset dir="${project.root}/src/main/asciidoc">
+												<include name="**/*.adoc"/>
+											</fileset>
+										</copy>
+										<copy failonerror="false" todir="${project.build.directory}/working/images">
+											<fileset dir="${project.root}/src/main/asciidoc/images">
+												<include name="*.*"/>
+											</fileset>
+										</copy>
+									</target>
+								</configuration>
+								<goals>
+									<goal>run</goal>
+								</goals>
+							</execution>
+
+							<execution>
 								<id>rename-reference-docs</id>
 								<phase>package</phase>
 								<configuration>
@@ -444,7 +507,7 @@
 										<goal>process-asciidoc</goal>
 									</goals>
 									<configuration>
-										<sourceDirectory>${project.root}/src/main/asciidoc</sourceDirectory>
+										<sourceDirectory>${project.build.directory}/working</sourceDirectory>
 										<backend>html5</backend>
 										<outputDirectory>${project.build.directory}/generated-docs</outputDirectory>
 										<sectids>false</sectids>
@@ -469,7 +532,7 @@
 										<goal>process-asciidoc</goal>
 									</goals>
 									<configuration>
-										<sourceDirectory>${project.root}/src/main/asciidoc</sourceDirectory>
+										<sourceDirectory>${project.build.directory}/working</sourceDirectory>
 										<sourceDocumentName>index.adoc</sourceDocumentName>
 										<backend>epub3</backend>
 										<outputDirectory>${project.build.directory}/generated-docs</outputDirectory>
@@ -485,7 +548,7 @@
 										<goal>process-asciidoc</goal>
 									</goals>
 									<configuration>
-										<sourceDirectory>${project.root}/src/main/asciidoc</sourceDirectory>
+										<sourceDirectory>${project.build.directory}/working</sourceDirectory>
 										<sourceDocumentName>index.adoc</sourceDocumentName>
 										<backend>pdf</backend>
 										<outputDirectory>${project.build.directory}/generated-docs</outputDirectory>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -341,12 +341,12 @@
 								<phase>generate-resources</phase>
 								<configuration>
 									<target>
-										<copy todir="${project.root}/target/site/reference/html">
+<!--										<copy todir="${project.root}/target/site/reference/html">
 											<fileset dir="${shared.resources}/asciidoc" erroronmissingdir="false">
 												<include name="**/*.css"/>
 											</fileset>
 											<flattenmapper/>
-										</copy>
+										</copy> -->
 										<copy todir="${project.root}/target/site/reference/html/images">
 											<fileset dir="${basedir}/src/main/asciidoc" erroronmissingdir="false">
 												<include name="**/*.png"/>
@@ -385,8 +385,27 @@
 								<phase>package</phase>
 								<configuration>
 									<target>
+
+										<!-- Copy files for the single-file HTML version -->
+										<copy failonerror="false" file="${project.build.directory}/generated-docs/index.html" tofile="${project.root}/target/site/reference/html/${dist.id}-reference.html"/>
+										<copy failonerror="false" todir="${project.root}/target/site/reference/html/images">
+											<fileset dir="${project.build.directory}/generated-docs/images">
+												<include name="*.*"/>
+											</fileset>
+										</copy>
+										<copy failonerror="false" todir="${project.root}/target/site/reference/html/tocbot-3.0.2">
+											<fileset dir="${project.build.directory}/generated-docs/tocbot-3.0.2">
+												<include name="*.*"/>
+											</fileset>
+										</copy>
+										<copy failonerror="false" file="${project.build.directory}/generated-docs/stylesheets/spring.css" tofile="${project.root}/target/site/reference/html/stylesheets/spring.css"/>
+
+										<!-- Copy and rename the Epub file -->
 										<copy failonerror="false" file="${project.build.directory}/generated-docs/index.pdf" tofile="${project.root}/target/site/reference/pdf/${dist.id}-reference.pdf"/>
+
+										<!-- Copy and rename the PDF file -->
 										<copy failonerror="false" file="${project.build.directory}/generated-docs/index.epub" tofile="${project.root}/target/site/reference/epub/${dist.id}-reference.epub"/>
+
 									</target>
 								</configuration>
 								<goals>
@@ -431,20 +450,24 @@
 										<goal>process-asciidoc</goal>
 									</goals>
 									<configuration>
+										<sourceDirectory>${project.root}/src/main/asciidoc</sourceDirectory>
 										<backend>html5</backend>
-										<outputDirectory>${project.root}/target/site/reference/html</outputDirectory>
+										<outputDirectory>${project.build.directory}/generated-docs</outputDirectory>
 										<sectids>false</sectids>
 										<sourceHighlighter>prettify</sourceHighlighter>
 										<attributes>
 											<linkcss>true</linkcss>
 											<icons>font</icons>
 											<sectanchors>true</sectanchors>
+											<stylesdir>./stylesheets</stylesdir>
 											<stylesheet>spring.css</stylesheet>
+											<docinfo>shared</docinfo>
+											<toc>left</toc>
 										</attributes>
 									</configuration>
 								</execution>
 
-<!--
+
 								<execution>
 									<id>epub</id>
 									<phase>prepare-package</phase>
@@ -452,7 +475,11 @@
 										<goal>process-asciidoc</goal>
 									</goals>
 									<configuration>
+										<sourceDirectory>${project.root}/src/main/asciidoc</sourceDirectory>
+										<sourceDocumentName>index.adoc</sourceDocumentName>
 										<backend>epub3</backend>
+										<outputDirectory>${project.build.directory}/generated-docs</outputDirectory>
+										<sectids>false</sectids>
 										<sourceHighlighter>coderay</sourceHighlighter>
 									</configuration>
 								</execution>
@@ -464,16 +491,18 @@
 										<goal>process-asciidoc</goal>
 									</goals>
 									<configuration>
+										<sourceDirectory>${project.root}/src/main/asciidoc</sourceDirectory>
+										<sourceDocumentName>index.adoc</sourceDocumentName>
 										<backend>pdf</backend>
+										<outputDirectory>${project.build.directory}/generated-docs</outputDirectory>
+										<sectids>false</sectids>
 										<sourceHighlighter>coderay</sourceHighlighter>
 									</configuration>
-								</execution>-->
+								</execution>
 
 							</executions>
 
 							<configuration>
-								<sourceDirectory>${project.root}/src/main/asciidoc</sourceDirectory>
-								<sourceDocumentName>index.adoc</sourceDocumentName>
 								<doctype>book</doctype>
 								<attributes>
 									<version>${project.version}</version>
@@ -484,7 +513,7 @@
 									<springVersion>${spring}</springVersion>
 									<releasetrainVersion>${releasetrain}</releasetrainVersion>
 									<allow-uri-read>true</allow-uri-read>
-									<toclevels>3</toclevels>
+									<toclevels>4</toclevels>
 									<numbered>true</numbered>
 								</attributes>
 							</configuration>


### PR DESCRIPTION
I made changes to the pom.xml file to get PDF and Epub output. In a nutshell, I ran everything into the generated-docs directory and then moved the required output files to their final locations.

Edited to add: I found that, once I got the resources from spring-doc-resources, I needed to set up a working directory to hold all the parts and then generate the docs from there. Asciidoctor requires the docinfo.html and docinfo-footer.html pages to be present for generation, so there's no way to generate straight from the source.