### PR TITLE
#587 - Attach Kotlin source dir to source code artifact.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -950,6 +950,25 @@
 			</plugin>
 
 			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>add-kotlin-source</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>${project.basedir}/src/main/kotlin</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
 				<groupId>org.projectlombok</groupId>
 				<artifactId>lombok-maven-plugin</artifactId>
 				<configuration>


### PR DESCRIPTION
Sources of Kotlin extensions stored under `src/main/kotlin` are not packed by `maven-source-plugin` into Maven sources artifact.

PR adds a `build-helper-maven-plugin` execution to attach Kotlin source directory to the set of source directories. That way its picked up by `maven-source-plugin` and packed into source code artifact. It's attached to `prepare-package` phase so it won't affect compilation in any way.

Fixes #587 