### PR TITLE
Upgrade to Coroutines 1.2.0-alpha-2

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -98,7 +98,7 @@
 		<jsonpath>2.4.0</jsonpath>
 		<junit>4.12</junit>
 		<kotlin>1.3.21</kotlin>
-		<kotlin-coroutines>1.1.1</kotlin-coroutines>
+		<kotlin-coroutines>1.2.0-alpha-2</kotlin-coroutines>
 		<logback>1.2.3</logback>
 		<lombok>1.18.6</lombok>
 		<mockito>2.23.4</mockito>


### PR DESCRIPTION
This version introduces `Flow` type (not final yet) that allows to expose `Flux` or `Publisher` to Coroutines world.