### PR TITLE
#877 - Upgrade to Coroutines 1.3.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -110,7 +110,7 @@
 		<jsonpath>2.4.0</jsonpath>
 		<junit>4.12</junit>
 		<kotlin>1.3.50</kotlin>
-		<kotlin-coroutines>1.2.1</kotlin-coroutines>
+		<kotlin-coroutines>1.3.0</kotlin-coroutines>
 		<logback>1.2.3</logback>
 		<lombok>1.18.8</lombok>
 		<mockito>3.0.0</mockito>
@@ -121,7 +121,7 @@
 		<rxjava-reactive-streams>1.2.1</rxjava-reactive-streams>
 		<rxjava2>2.2.12</rxjava2>
 		<slf4j>1.7.26</slf4j>
-		<spring>5.2.0.RC1</spring>
+		<spring>5.2.0.BUILD-SNAPSHOT</spring>
 		<spring-hateoas>1.0.0.RC1</spring-hateoas>
 		<testcontainers>1.12.0</testcontainers>
 		<threetenbp>1.4.0</threetenbp>
@@ -909,6 +909,13 @@
 				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-bom</artifactId>
 				<version>${kotlin}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlinx</groupId>
+				<artifactId>kotlinx-coroutines-bom</artifactId>
+				<version>${kotlin-coroutines}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
Coroutines BOM is now used for dependency management.

