### PR TITLE
Use the correct version for the API links.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1269,7 +1269,7 @@
 						<additionalOption>-Xdoclint:none</additionalOption>
 					</additionalOptions>
 					<links>
-						<link>https://docs.spring.io/spring/docs/5.0.x/javadoc-api/</link>
+						<link>https://docs.spring.io/spring/docs/${spring}/javadoc-api/</link>
 						<link>https://docs.spring.io/spring-data/commons/docs/current/api/</link>
 						<link>https://docs.oracle.com/javase/8/docs/api/</link>
 					</links>


### PR DESCRIPTION
I added a JIRA ticket for commons before I realized that this is an issue for spring-data-build: https://jira.spring.io/browse/DATACMNS-1826

We should use the exact version here or `current` as well.