### PR TITLE
Upgrade-to-OpenWebBeans-2.0.22.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -131,7 +131,7 @@
 		<testcontainers>1.15.2</testcontainers>
 		<threetenbp>1.5.0</threetenbp>
 		<validation>1.1.0.Final</validation>
-		<webbeans>2.0.21</webbeans>
+		<webbeans>2.0.22</webbeans>
 		<javax-annotation-api>1.3.2</javax-annotation-api>
 
 		<!-- Used in asciidoc reference documentation -->


### PR DESCRIPTION
The dependency for OpenWebBeans needs to be updated to 2.0.22 in order to enable builds with AdoptOpenJDK 16.