### PR TITLE
Use release javac option instead of source/target

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1180,8 +1180,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>${source.level}</source>
-					<target>${source.level}</target>
+					<release>${source.level}</release>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
Replaced old source/target options with the new (as of JDK 9) `release` option which (besides reduced duplication) also allows cross compilation between various JDK releases by also supporting bootclasspath from older JDK releases.
