### PR TITLE
Run nested tests by default.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1361,6 +1361,7 @@
 					<includes>
 						<include>**/*Tests.java</include>
 					</includes>
+					<excludes><exclude/></excludes>
 				</configuration>
 			</plugin>
 
@@ -1370,6 +1371,7 @@
 				<configuration>
 					<useFile>false</useFile>
 					<argLine>-Xverify:all</argLine>
+					<excludes><exclude/></excludes>
 				</configuration>
 			</plugin>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-build</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-enable-nested-tests-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -397,7 +397,7 @@
 				<dependency>
 					<groupId>org.springframework.data.build</groupId>
 					<artifactId>spring-data-build-resources</artifactId>
-					<version>3.2.0-SNAPSHOT</version>
+					<version>3.2.0-enable-nested-tests-SNAPSHOT</version>
 					<type>zip</type>
 					<optional>true</optional>
 				</dependency>
@@ -690,7 +690,7 @@
 				<dependency>
 					<groupId>org.springframework.data.build</groupId>
 					<artifactId>spring-data-build-resources</artifactId>
-					<version>3.2.0-SNAPSHOT</version>
+					<version>3.2.0-enable-nested-tests-SNAPSHOT</version>
 					<type>zip</type>
 					<optional>true</optional>
 				</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.data.build</groupId>
 	<artifactId>spring-data-build</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-enable-nested-tests-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Build</name>

--- a/resources/pom.xml
+++ b/resources/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-build</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-enable-nested-tests-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
Surefire and Failsafe plugins by default exclude nested classes.
This overwrites these excludes with empty ones, thus enabling execution of nested classes.

See [https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html\#excludes](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html/#excludes)