### PR TITLE
harden: github actions step uses a mutable tag or branc... in...

### DIFF
--- a/actions/maven-artifactory-deploy/action.yaml
+++ b/actions/maven-artifactory-deploy/action.yaml
@@ -135,7 +135,7 @@ runs:
         -Dmaven.test.skip=${SKIP_TESTS} -U -B\
         clean deploy
     - name: Test Summary
-      uses: spring-projects/spring-data-build/actions/test-summary@main
+      uses: spring-projects/spring-data-build/actions/test-summary@bea433eede5cb4d98cf3677b91ec49260503d25e
       with:
         paths: '**/TEST-*.xml'
       if: always()


### PR DESCRIPTION
## Summary
Harden input handling in `actions/maven-artifactory-deploy/action.yaml` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag` |
| **File** | `actions/maven-artifactory-deploy/action.yaml:138` |
| **Assessment** | Defensive hardening |

**Description**: GitHub Actions step uses a mutable tag or branch reference. Tags and branch names can be silently repointed by the action owner, enabling supply-chain attacks — as seen in the trivy-action and kics-github-action compromises. Pin the reference to a full 40-character commit SHA instead, e.g. `uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608`.

## Threat Model Context

This is a Java service - vulnerabilities in servlets/controllers are remotely exploitable.

## Changes
- `actions/maven-artifactory-deploy/action.yaml`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
